### PR TITLE
Max CredentialBlobSize is 512*5 bytes

### DIFF
--- a/Credential.cs
+++ b/Credential.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace CredentialManagement
 {
-    public class Credential: IDisposable
+    public class Credential : IDisposable
     {
 
         static object _lockObject = new object();
@@ -89,7 +89,8 @@ namespace CredentialManagement
         }
 
 
-        public string Username {
+        public string Username
+        {
             get
             {
                 CheckNotDisposed();
@@ -166,8 +167,8 @@ namespace CredentialManagement
                 return LastWriteTimeUtc.ToLocalTime();
             }
         }
-        public DateTime LastWriteTimeUtc 
-        { 
+        public DateTime LastWriteTimeUtc
+        {
             get
             {
                 CheckNotDisposed();
@@ -209,7 +210,7 @@ namespace CredentialManagement
             CheckNotDisposed();
 
             byte[] passwordBytes = Encoding.Unicode.GetBytes(Password);
-            if (Password.Length > (512))
+            if (Password.Length > (512 * 5))
             {
                 throw new ArgumentOutOfRangeException("The password has exceeded 512 bytes.");
             }
@@ -221,7 +222,7 @@ namespace CredentialManagement
             credential.CredentialBlobSize = passwordBytes.Length;
             credential.Comment = Description;
             credential.Type = (int)Type;
-            credential.Persist = (int) PersistanceType;
+            credential.Persist = (int)PersistanceType;
 
             bool result = NativeMethods.CredWrite(ref credential, 0);
             if (!result)

--- a/Credential.cs
+++ b/Credential.cs
@@ -212,7 +212,7 @@ namespace CredentialManagement
             byte[] passwordBytes = Encoding.Unicode.GetBytes(Password);
             if (Password.Length > (512 * 5))
             {
-                throw new ArgumentOutOfRangeException("The password has exceeded 512 bytes.");
+                throw new ArgumentOutOfRangeException($"The password has exceeded 512 * 5 bytes as it was {passwordBytes.Length}.");
             }
 
             NativeMethods.CREDENTIAL credential = new NativeMethods.CREDENTIAL();


### PR DESCRIPTION
According to the docs, the max CredentialBlobSize is 512*5 bytes these days, not just 512 bytes anymore:
https://learn.microsoft.com/en-us/windows/win32/api/wincred/ns-wincred-credentiala